### PR TITLE
Fix the year comparisons in monthsInDateRangeForYear.

### DIFF
--- a/src/extractDateRangeFromGoogleTakeout.mjs
+++ b/src/extractDateRangeFromGoogleTakeout.mjs
@@ -55,13 +55,13 @@ const monthsInDateRangeForYear = ({ start: startDate, end: endDate }, year) => {
     let startMonth;
     let endMonth;
 
-    if (startDate.getUTCFullYear < year) {
+    if (startDate.getUTCFullYear() < year) {
         startMonth = 0;
     } else {
         startMonth = startDate.getUTCMonth();
     }
 
-    if (endDate.getUTCFullYear > year) {
+    if (endDate.getUTCFullYear() > year) {
         endMonth = 11;
     } else {
         endMonth = endDate.getUTCMonth();


### PR DESCRIPTION
If you run this script now, in February, it only attempts to parse January and February of each year, because the end date comparison always returns false.